### PR TITLE
Add begin/end documentation alongside cbegin/cend

### DIFF
--- a/_docs/deque_of_unique/cbegin.html
+++ b/_docs/deque_of_unique/cbegin.html
@@ -10,7 +10,7 @@ title: begin, cbegin
       <td>
         <div>
           <span class="mw-geshi cpp source-cpp"
-            >iterator begin<span class="br0">(</span
+            >const_iterator begin<span class="br0">(</span
             ><span class="br0">)</span> <span class="kw4">const</span
             ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
           >

--- a/_docs/deque_of_unique/cbegin.html
+++ b/_docs/deque_of_unique/cbegin.html
@@ -1,11 +1,23 @@
 ---
-last_modified_at: "2025-01-04 13:13:57 +0800"
+last_modified_at: "2026-03-20 00:00:00 +0800"
 layout: deque_of_unique_method
-title: cbegin
+title: begin, cbegin
 ---
 
 <table class="t-dcl-begin">
   <tbody>
+    <tr class="t-dcl">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            >iterator begin<span class="br0">(</span
+            ><span class="br0">)</span> <span class="kw4">const</span
+            ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td><span class="number">(1)</span></td>
+    </tr>
     <tr class="t-dcl">
       <td>
         <div>
@@ -16,6 +28,7 @@ title: cbegin
           >
         </div>
       </td>
+      <td><span class="number">(2)</span></td>
     </tr>
     <tr class="t-dcl-sep">
       <td></td>
@@ -30,7 +43,15 @@ title: cbegin
   <span class="t-lc"
     ><a
       href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
-      title="containerofunique/deque_of_unique/crend"
+      title="containerofunique/deque_of_unique/cend"
+      >end()</a
+    ></span
+  >
+  /
+  <span class="t-lc"
+    ><a
+      href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
+      title="containerofunique/deque_of_unique/cend"
       >cend()</a
     ></span
   >.

--- a/_docs/deque_of_unique/cend.html
+++ b/_docs/deque_of_unique/cend.html
@@ -1,11 +1,23 @@
 ---
-last_modified_at: "2025-01-04 13:13:57 +0800"
+last_modified_at: "2026-03-20 00:00:00 +0800"
 layout: deque_of_unique_method
-title: cend
+title: end, cend
 ---
 
 <table class="t-dcl-begin">
   <tbody>
+    <tr class="t-dcl">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            >iterator end<span class="br0">(</span
+            ><span class="br0">)</span> <span class="kw4">const</span
+            ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td><span class="number">(1)</span></td>
+    </tr>
     <tr class="t-dcl">
       <td>
         <div>
@@ -16,6 +28,7 @@ title: cend
           >
         </div>
       </td>
+      <td><span class="number">(2)</span></td>
     </tr>
     <tr class="t-dcl-sep">
       <td></td>

--- a/_docs/deque_of_unique/cend.html
+++ b/_docs/deque_of_unique/cend.html
@@ -10,7 +10,7 @@ title: end, cend
       <td>
         <div>
           <span class="mw-geshi cpp source-cpp"
-            >iterator end<span class="br0">(</span
+            >const_iterator end<span class="br0">(</span
             ><span class="br0">)</span> <span class="kw4">const</span
             ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
           >

--- a/_docs/deque_of_unique/index.html
+++ b/_docs/deque_of_unique/index.html
@@ -611,7 +611,7 @@ title: deque_of_unique
         </div>
       </td>
       <td>
-        &nbsp;return a reverse iterator to the begining&nbsp;
+        &nbsp;return a reverse iterator to the beginning&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>
@@ -813,7 +813,7 @@ title: deque_of_unique
         </div>
       </td>
       <td>
-        &nbsp;inserts an element to the begining&nbsp;
+        &nbsp;inserts an element to the beginning&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>
@@ -832,7 +832,7 @@ title: deque_of_unique
         </div>
       </td>
       <td>
-        &nbsp;constructs element in-place at the begining&nbsp;
+        &nbsp;constructs element in-place at the beginning&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>

--- a/_docs/deque_of_unique/index.html
+++ b/_docs/deque_of_unique/index.html
@@ -567,7 +567,7 @@ title: deque_of_unique
             <a href="cbegin" title="containerofunique/deque_of_unique/cbegin">
               <span>begin</span>
             </a>
-            <span class="t-dsc-member-div-nopad"> </span>
+            <span class="t-dsc-member-div-nopad"> / </span>
             <a href="cbegin" title="containerofunique/deque_of_unique/cbegin">
               <span>cbegin</span>
             </a>

--- a/_docs/deque_of_unique/index.html
+++ b/_docs/deque_of_unique/index.html
@@ -565,13 +565,17 @@ title: deque_of_unique
         <div class="t-dsc-member-div">
           <div>
             <a href="cbegin" title="containerofunique/deque_of_unique/cbegin">
+              <span>begin</span>
+            </a>
+            <span class="t-dsc-member-div-nopad"> </span>
+            <a href="cbegin" title="containerofunique/deque_of_unique/cbegin">
               <span>cbegin</span>
             </a>
           </div>
         </div>
       </td>
       <td>
-        &nbsp;return an iterator to the begining&nbsp;
+        &nbsp;return an iterator to the beginning&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>
@@ -580,6 +584,10 @@ title: deque_of_unique
       <td>
         <div class="t-dsc-member-div">
           <div>
+            <a href="cend" title="containerofunique/deque_of_unique/cend">
+              <span>end</span>
+            </a>
+            <span class="t-dsc-member-div-nopad"> </span>
             <a href="cend" title="containerofunique/deque_of_unique/cend">
               <span>cend</span>
             </a>

--- a/_docs/vector_of_unique/cbegin.html
+++ b/_docs/vector_of_unique/cbegin.html
@@ -10,7 +10,7 @@ title: begin, cbegin
       <td>
         <div>
           <span class="mw-geshi cpp source-cpp"
-            >iterator begin<span class="br0">(</span
+            >const_iterator begin<span class="br0">(</span
             ><span class="br0">)</span> <span class="kw4">const</span
             ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
           >

--- a/_docs/vector_of_unique/cbegin.html
+++ b/_docs/vector_of_unique/cbegin.html
@@ -1,11 +1,23 @@
 ---
-last_modified_at: "2025-04-23 21:58:28 +0800"
+last_modified_at: "2026-03-20 00:00:00 +0800"
 layout: vector_of_unique_method
-title: cbegin
+title: begin, cbegin
 ---
 
 <table class="t-dcl-begin">
   <tbody>
+    <tr class="t-dcl">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            >iterator begin<span class="br0">(</span
+            ><span class="br0">)</span> <span class="kw4">const</span
+            ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td><span class="number">(1)</span></td>
+    </tr>
     <tr class="t-dcl">
       <td>
         <div>
@@ -16,6 +28,7 @@ title: cbegin
           >
         </div>
       </td>
+      <td><span class="number">(2)</span></td>
     </tr>
     <tr class="t-dcl-sep">
       <td></td>
@@ -43,7 +56,15 @@ title: cbegin
   <span class="t-lc"
     ><a
       href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
-      title="containerofunique/vector_of_unique/crend"
+      title="containerofunique/vector_of_unique/cend"
+      >end()</a
+    ></span
+  >
+  /
+  <span class="t-lc"
+    ><a
+      href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+      title="containerofunique/vector_of_unique/cend"
       >cend()</a
     ></span
   >.

--- a/_docs/vector_of_unique/cend.html
+++ b/_docs/vector_of_unique/cend.html
@@ -1,11 +1,23 @@
 ---
-last_modified_at: "2025-04-23 21:58:28 +0800"
+last_modified_at: "2026-03-20 00:00:00 +0800"
 layout: vector_of_unique_method
-title: cend
+title: end, cend
 ---
 
 <table class="t-dcl-begin">
   <tbody>
+    <tr class="t-dcl">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            >iterator end<span class="br0">(</span
+            ><span class="br0">)</span> <span class="kw4">const</span
+            ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td><span class="number">(1)</span></td>
+    </tr>
     <tr class="t-dcl">
       <td>
         <div>
@@ -16,6 +28,7 @@ title: cend
           >
         </div>
       </td>
+      <td><span class="number">(2)</span></td>
     </tr>
     <tr class="t-dcl-sep">
       <td></td>

--- a/_docs/vector_of_unique/cend.html
+++ b/_docs/vector_of_unique/cend.html
@@ -10,7 +10,7 @@ title: end, cend
       <td>
         <div>
           <span class="mw-geshi cpp source-cpp"
-            >iterator end<span class="br0">(</span
+            >const_iterator end<span class="br0">(</span
             ><span class="br0">)</span> <span class="kw4">const</span
             ><span class="kw1"> noexcept</span><span class="sy4">;</span></span
           >

--- a/_docs/vector_of_unique/index.html
+++ b/_docs/vector_of_unique/index.html
@@ -610,13 +610,17 @@ title: vector_of_unique
         <div class="t-dsc-member-div">
           <div>
             <a href="cbegin" title="containerofunique/vector_of_unique/cbegin">
+              <span>begin</span>
+            </a>
+            <span class="t-dsc-member-div-nopad"> </span>
+            <a href="cbegin" title="containerofunique/vector_of_unique/cbegin">
               <span>cbegin</span>
             </a>
           </div>
         </div>
       </td>
       <td>
-        &nbsp;return an iterator to the begining&nbsp;
+        &nbsp;return an iterator to the beginning&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>
@@ -625,6 +629,10 @@ title: vector_of_unique
       <td>
         <div class="t-dsc-member-div">
           <div>
+            <a href="cend" title="containerofunique/vector_of_unique/cend">
+              <span>end</span>
+            </a>
+            <span class="t-dsc-member-div-nopad"> </span>
             <a href="cend" title="containerofunique/vector_of_unique/cend">
               <span>cend</span>
             </a>

--- a/_docs/vector_of_unique/index.html
+++ b/_docs/vector_of_unique/index.html
@@ -659,7 +659,7 @@ title: vector_of_unique
         </div>
       </td>
       <td>
-        &nbsp;return a reverse iterator to the begining&nbsp;
+        &nbsp;return a reverse iterator to the beginning&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>


### PR DESCRIPTION
## Summary

- Updated `cbegin.html` to document both `begin()` and `cbegin()` on the same page (matching cppreference style)
- Updated `cend.html` to document both `end()` and `cend()` on the same page
- Applied to both `vector_of_unique` and `deque_of_unique`
- Updated index pages to list `begin`/`cbegin` and `end`/`cend` entries together
- Fixed typo: `begining` → `beginning` in index pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)