### PR TITLE
Add range modifiers, equal_range, and heterogeneous lookup notes

### DIFF
--- a/_docs/deque_of_unique/append_range.html
+++ b/_docs/deque_of_unique/append_range.html
@@ -1,0 +1,63 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: deque_of_unique_method
+title: append_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx23">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> R <span class="sy1">&gt;</span><br />
+            <span class="kw4">void</span> append_range<span class="br0">(</span>R<span class="sy3">&amp;&amp;</span> rng<span class="br0">)</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td><span class="t-mark-rev t-since-cxx23">(since C++23)</span></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  Appends unique elements from the range
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>
+  to the end of the container. Elements already present in the container and
+  intra-range duplicates are silently skipped.
+</p>
+<p>
+  Only available when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>rng</td>
+      <td>-</td>
+      <td>a range of elements to append</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>(none)</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  Average case: linear in the size of
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Worst case: quadratic.
+</p>

--- a/_docs/deque_of_unique/append_range.html
+++ b/_docs/deque_of_unique/append_range.html
@@ -37,6 +37,15 @@ title: append_range
   Only available when
   <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
 </p>
+<p>
+  All iterators (including the
+  <a
+    href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
+    title="containerofunique/deque_of_unique/cend"
+    ><code>cend()</code></a
+  >
+  iterator) are invalidated. No references are invalidated.
+</p>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>
 </h3>

--- a/_docs/deque_of_unique/assign_range.html
+++ b/_docs/deque_of_unique/assign_range.html
@@ -1,0 +1,63 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: deque_of_unique_method
+title: assign_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx23">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> R <span class="sy1">&gt;</span><br />
+            <span class="kw4">void</span> assign_range<span class="br0">(</span>R<span class="sy3">&amp;&amp;</span> rng<span class="br0">)</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td><span class="t-mark-rev t-since-cxx23">(since C++23)</span></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  Replaces the contents of the container with the unique elements from the range
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Intra-range duplicates are silently skipped. All iterators and references to
+  the elements are invalidated.
+</p>
+<p>
+  Only available when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>rng</td>
+      <td>-</td>
+      <td>a range of elements to assign from</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>(none)</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  Average case: linear in the size of
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Worst case: quadratic.
+</p>

--- a/_docs/deque_of_unique/equal_range.html
+++ b/_docs/deque_of_unique/equal_range.html
@@ -1,0 +1,99 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: deque_of_unique_method
+title: equal_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx11">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><a
+              href="https://en.cppreference.com/w/cpp/utility/pair"
+              title="std::pair"
+              ><span class="kw1773">std::<span class="me2">pair</span></span></a
+            ><span class="sy1">&lt;</span>const_iterator, const_iterator<span
+              class="sy1"
+              >&gt;</span
+            >
+            equal_range<span class="br0">(</span>
+            <span class="kw4">const</span> Key<span class="sy3">&amp;</span> key
+            <span class="br0">)</span> <span class="kw4">const</span
+            ><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="t-li1">
+  <span class="t-li">1)</span> Returns a range containing all elements with key
+  equivalent to
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">key</span></span>.
+  Since all elements in the container are unique, the returned range contains at
+  most one element.
+</div>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>key</td>
+      <td>-</td>
+      <td>key value of the elements to search for</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>
+  A
+  <span class="t-lc"
+    ><a
+      href="https://en.cppreference.com/w/cpp/utility/pair"
+      title="std::pair"
+      >std::pair</a
+    ></span
+  >
+  of
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp">const_iterator</span></span
+  >s. Since all elements are unique, the range is either
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">{it, it+1}</span></span>
+  if an element with the given key is found, or
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >{<a
+        href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
+        title="containerofunique/deque_of_unique/cend"
+        >cend()</a
+      >,
+      <a
+        href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
+        title="containerofunique/deque_of_unique/cend"
+        >cend()</a
+      >}</span
+    ></span
+  >
+  if not found.
+</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  <span class="texhtml" style="white-space: nowrap">O(N)</span>, where
+  <span class="texhtml" style="white-space: nowrap">N</span> is the size of the
+  container.
+</p>

--- a/_docs/deque_of_unique/equal_range.html
+++ b/_docs/deque_of_unique/equal_range.html
@@ -28,6 +28,31 @@ title: equal_range
       <td>(1)</td>
       <td></td>
     </tr>
+    <tr class="t-dcl t-since-cxx20">
+      <td>
+        <div>
+          <span id="Version_2"></span
+          ><span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> K <span class="sy1">&gt;</span><br />
+            <a
+              href="https://en.cppreference.com/w/cpp/utility/pair"
+              title="std::pair"
+              ><span class="kw1773">std::<span class="me2">pair</span></span></a
+            ><span class="sy1">&lt;</span>const_iterator, const_iterator<span
+              class="sy1"
+              >&gt;</span
+            >
+            equal_range<span class="br0">(</span>
+            <span class="kw4">const</span> K<span class="sy3">&amp;</span> x
+            <span class="br0">)</span> <span class="kw4">const</span
+            ><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(2)</td>
+      <td><span class="t-mark-rev t-since-cxx20">(since C++20)</span></td>
+    </tr>
     <tr class="t-dcl-sep">
       <td></td>
       <td></td>
@@ -43,6 +68,29 @@ title: equal_range
   Since all elements in the container are unique, the returned range contains at
   most one element.
 </div>
+<div class="t-li1">
+  <span class="t-li">2)</span> Returns a range containing all elements with key
+  that compares <i>equivalent</i> to the value
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">x</span></span
+  >. This overload participates in overload resolution only if
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >Hash<span class="sy4">::</span
+      ><span class="me2">is_transparent</span></span
+    ></span
+  >
+  and
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >KeyEqual<span class="sy4">::</span
+      ><span class="me2">is_transparent</span></span
+    ></span
+  >
+  are valid and each denotes a type. This assumes that such <code>Hash</code> is
+  callable with both <code>K</code> and <code>Key</code> type, and that the
+  <code>KeyEqual</code> is transparent, which, together, allows calling this
+  function without constructing an instance of <code>Key</code>.
+</div>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>
 </h3>
@@ -52,6 +100,11 @@ title: equal_range
       <td>key</td>
       <td>-</td>
       <td>key value of the elements to search for</td>
+    </tr>
+    <tr class="t-par">
+      <td>x</td>
+      <td>-</td>
+      <td>a value of any type that can be transparently compared with a key</td>
     </tr>
   </tbody>
 </table>

--- a/_docs/deque_of_unique/equal_range.html
+++ b/_docs/deque_of_unique/equal_range.html
@@ -146,7 +146,9 @@ title: equal_range
   <span class="mw-headline" id="Complexity">Complexity</span>
 </h3>
 <p>
-  <span class="texhtml" style="white-space: nowrap">O(N)</span>, where
-  <span class="texhtml" style="white-space: nowrap">N</span> is the size of the
-  container.
+  Average case: <span class="texhtml" style="white-space: nowrap">O(N)</span>,
+  where <span class="texhtml" style="white-space: nowrap">N</span> is the size
+  of the container (hash lookup is O(1) average, but a linear scan of the
+  sequence is required to obtain a sequence iterator).<br />
+  Worst case: <span class="texhtml" style="white-space: nowrap">O(N)</span>.
 </p>

--- a/_docs/deque_of_unique/index.html
+++ b/_docs/deque_of_unique/index.html
@@ -872,6 +872,110 @@ title: deque_of_unique
         <span class="t-mark">(public member function)</span>
       </td>
     </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="assign_range"
+              title="containerofunique/deque_of_unique/assign_range"
+            >
+              <span>assign_range</span>
+            </a>
+          </div>
+          <div>
+            <span class="t-lines"
+              ><span
+                ><span class="t-mark-rev t-since-cxx23">(C++23)</span></span
+              ></span
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;replaces contents with unique elements from a range&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="insert_range"
+              title="containerofunique/deque_of_unique/insert_range"
+            >
+              <span>insert_range</span>
+            </a>
+          </div>
+          <div>
+            <span class="t-lines"
+              ><span
+                ><span class="t-mark-rev t-since-cxx23">(C++23)</span></span
+              ></span
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;inserts unique elements from a range before a position&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="append_range"
+              title="containerofunique/deque_of_unique/append_range"
+            >
+              <span>append_range</span>
+            </a>
+          </div>
+          <div>
+            <span class="t-lines"
+              ><span
+                ><span class="t-mark-rev t-since-cxx23">(C++23)</span></span
+              ></span
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;appends unique elements from a range to the end&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="prepend_range"
+              title="containerofunique/deque_of_unique/prepend_range"
+            >
+              <span>prepend_range</span>
+            </a>
+          </div>
+          <div>
+            <span class="t-lines"
+              ><span
+                ><span class="t-mark-rev t-since-cxx23">(C++23)</span></span
+              ></span
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;prepends unique elements from a range to the front&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
     <tr>
       <td colspan="2">
         <h5>
@@ -890,7 +994,9 @@ title: deque_of_unique
         </div>
       </td>
       <td>
-        &nbsp;finds element with specific key&nbsp;
+        &nbsp;finds element with specific key; supports heterogeneous lookup
+        (C++20) when <code>Hash::is_transparent</code> and
+        <code>KeyEqual::is_transparent</code> are defined&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>
@@ -916,7 +1022,29 @@ title: deque_of_unique
         </div>
       </td>
       <td>
-        &nbsp;checks if the container contains element with specific key&nbsp;
+        &nbsp;checks if the container contains element with specific key;
+        supports heterogeneous lookup (C++20) when
+        <code>Hash::is_transparent</code> and
+        <code>KeyEqual::is_transparent</code> are defined&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="equal_range"
+              title="containerofunique/deque_of_unique/equal_range"
+            >
+              <span>equal_range</span>
+            </a>
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;returns range of elements matching a specific key&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>

--- a/_docs/deque_of_unique/index.html
+++ b/_docs/deque_of_unique/index.html
@@ -1044,7 +1044,9 @@ title: deque_of_unique
         </div>
       </td>
       <td>
-        &nbsp;returns range of elements matching a specific key&nbsp;
+        &nbsp;returns range of elements matching a specific key; supports
+        heterogeneous lookup (C++20) when <code>Hash::is_transparent</code> and
+        <code>KeyEqual::is_transparent</code> are defined&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>

--- a/_docs/deque_of_unique/insert_range.html
+++ b/_docs/deque_of_unique/insert_range.html
@@ -1,0 +1,74 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: deque_of_unique_method
+title: insert_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx23">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> R <span class="sy1">&gt;</span><br />
+            iterator insert_range<span class="br0">(</span>const_iterator pos, R<span class="sy3">&amp;&amp;</span> rng<span class="br0">)</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td><span class="t-mark-rev t-since-cxx23">(since C++23)</span></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  Inserts unique elements from the range
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>
+  before
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">pos</span></span>.
+  Elements already present in the container and intra-range duplicates are
+  silently skipped.
+</p>
+<p>
+  Only available when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>pos</td>
+      <td>-</td>
+      <td>iterator before which the new elements will be inserted</td>
+    </tr>
+    <tr class="t-par">
+      <td>rng</td>
+      <td>-</td>
+      <td>a range of elements to insert</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>
+  Iterator pointing to the first inserted element, or
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">pos</span></span>
+  if no elements were inserted.
+</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  Average case: linear in the size of
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Worst case: quadratic.
+</p>

--- a/_docs/deque_of_unique/insert_range.html
+++ b/_docs/deque_of_unique/insert_range.html
@@ -39,6 +39,36 @@ title: insert_range
   Only available when
   <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
 </p>
+<p>
+  All iterators (including the
+  <a
+    href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
+    title="containerofunique/deque_of_unique/cend"
+    ><code>cend()</code></a
+  >
+  iterator) are invalidated. References are invalidated too, unless
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >pos <span class="sy1">==</span></span
+    ><code>&nbsp;</code
+    ><a
+      href="{{ '/_docs/deque_of_unique/cbegin' | relative_url }}"
+      title="containerofunique/deque_of_unique/cbegin"
+      ><code>cbegin()</code></a
+    ></span
+  >
+  or
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >pos <span class="sy1">==</span></span
+    ><code>&nbsp;</code
+    ><a
+      href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
+      title="containerofunique/deque_of_unique/cend"
+      ><code>cend()</code></a
+    ></span
+  >, in which case they are not invalidated.
+</p>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>
 </h3>

--- a/_docs/deque_of_unique/prepend_range.html
+++ b/_docs/deque_of_unique/prepend_range.html
@@ -37,6 +37,15 @@ title: prepend_range
   Only available for <code>deque_of_unique</code> when
   <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
 </p>
+<p>
+  All iterators (including the
+  <a
+    href="{{ '/_docs/deque_of_unique/cend' | relative_url }}"
+    title="containerofunique/deque_of_unique/cend"
+    ><code>cend()</code></a
+  >
+  iterator) are invalidated. No references are invalidated.
+</p>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>
 </h3>

--- a/_docs/deque_of_unique/prepend_range.html
+++ b/_docs/deque_of_unique/prepend_range.html
@@ -1,0 +1,63 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: deque_of_unique_method
+title: prepend_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx23">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> R <span class="sy1">&gt;</span><br />
+            <span class="kw4">void</span> prepend_range<span class="br0">(</span>R<span class="sy3">&amp;&amp;</span> rng<span class="br0">)</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td><span class="t-mark-rev t-since-cxx23">(since C++23)</span></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  Prepends unique elements from the range
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>
+  to the front of the container. Elements already present in the container and
+  intra-range duplicates are silently skipped.
+</p>
+<p>
+  Only available for <code>deque_of_unique</code> when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>rng</td>
+      <td>-</td>
+      <td>a range of elements to prepend</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>(none)</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  Average case: linear in the size of
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Worst case: quadratic.
+</p>

--- a/_docs/vector_of_unique/append_range.html
+++ b/_docs/vector_of_unique/append_range.html
@@ -37,6 +37,26 @@ title: append_range
   Only available when
   <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
 </p>
+<p>
+  If after the operation the new
+  <a href="{{ '/_docs/vector_of_unique/size' | relative_url }}"
+    title="containerofunique/vector_of_unique/size"><code>size()</code></a>
+  is greater than the old capacity, a reallocation takes place, in which case
+  all iterators (including the
+  <a
+    href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+    title="containerofunique/vector_of_unique/cend"
+    ><code>cend()</code></a
+  >
+  iterator) and all references to the elements are invalidated. Otherwise only
+  the
+  <a
+    href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+    title="containerofunique/vector_of_unique/cend"
+    ><code>cend()</code></a
+  >
+  iterator is invalidated.
+</p>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>
 </h3>

--- a/_docs/vector_of_unique/append_range.html
+++ b/_docs/vector_of_unique/append_range.html
@@ -1,0 +1,63 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: vector_of_unique_method
+title: append_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx23">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> R <span class="sy1">&gt;</span><br />
+            <span class="kw4">void</span> append_range<span class="br0">(</span>R<span class="sy3">&amp;&amp;</span> rng<span class="br0">)</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td><span class="t-mark-rev t-since-cxx23">(since C++23)</span></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  Appends unique elements from the range
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>
+  to the end of the container. Elements already present in the container and
+  intra-range duplicates are silently skipped.
+</p>
+<p>
+  Only available when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>rng</td>
+      <td>-</td>
+      <td>a range of elements to append</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>(none)</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  Average case: linear in the size of
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Worst case: quadratic.
+</p>

--- a/_docs/vector_of_unique/assign_range.html
+++ b/_docs/vector_of_unique/assign_range.html
@@ -1,0 +1,63 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: vector_of_unique_method
+title: assign_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx23">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> R <span class="sy1">&gt;</span><br />
+            <span class="kw4">void</span> assign_range<span class="br0">(</span>R<span class="sy3">&amp;&amp;</span> rng<span class="br0">)</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td><span class="t-mark-rev t-since-cxx23">(since C++23)</span></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  Replaces the contents of the container with the unique elements from the range
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Intra-range duplicates are silently skipped. All iterators and references to
+  the elements are invalidated.
+</p>
+<p>
+  Only available when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>rng</td>
+      <td>-</td>
+      <td>a range of elements to assign from</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>(none)</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  Average case: linear in the size of
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Worst case: quadratic.
+</p>

--- a/_docs/vector_of_unique/assign_range.html
+++ b/_docs/vector_of_unique/assign_range.html
@@ -27,12 +27,16 @@ title: assign_range
   </tbody>
 </table>
 
-<p>
   Replaces the contents of the container with the unique elements from the range
   <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
-  Intra-range duplicates are silently skipped. All iterators and references to
-  the elements are invalidated.
+  Intra-range duplicates are silently skipped.
 </p>
+<p>
+  Only available when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<p>
+  All iterators and references to the elements are invalidated.
 <p>
   Only available when
   <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.

--- a/_docs/vector_of_unique/equal_range.html
+++ b/_docs/vector_of_unique/equal_range.html
@@ -28,6 +28,31 @@ title: equal_range
       <td>(1)</td>
       <td></td>
     </tr>
+    <tr class="t-dcl t-since-cxx20">
+      <td>
+        <div>
+          <span id="Version_2"></span
+          ><span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> K <span class="sy1">&gt;</span><br />
+            <a
+              href="https://en.cppreference.com/w/cpp/utility/pair"
+              title="std::pair"
+              ><span class="kw1773">std::<span class="me2">pair</span></span></a
+            ><span class="sy1">&lt;</span>const_iterator, const_iterator<span
+              class="sy1"
+              >&gt;</span
+            >
+            equal_range<span class="br0">(</span>
+            <span class="kw4">const</span> K<span class="sy3">&amp;</span> x
+            <span class="br0">)</span> <span class="kw4">const</span
+            ><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(2)</td>
+      <td><span class="t-mark-rev t-since-cxx20">(since C++20)</span></td>
+    </tr>
     <tr class="t-dcl-sep">
       <td></td>
       <td></td>
@@ -43,6 +68,29 @@ title: equal_range
   Since all elements in the container are unique, the returned range contains at
   most one element.
 </div>
+<div class="t-li1">
+  <span class="t-li">2)</span> Returns a range containing all elements with key
+  that compares <i>equivalent</i> to the value
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">x</span></span
+  >. This overload participates in overload resolution only if
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >Hash<span class="sy4">::</span
+      ><span class="me2">is_transparent</span></span
+    ></span
+  >
+  and
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >KeyEqual<span class="sy4">::</span
+      ><span class="me2">is_transparent</span></span
+    ></span
+  >
+  are valid and each denotes a type. This assumes that such <code>Hash</code> is
+  callable with both <code>K</code> and <code>Key</code> type, and that the
+  <code>KeyEqual</code> is transparent, which, together, allows calling this
+  function without constructing an instance of <code>Key</code>.
+</div>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>
 </h3>
@@ -52,6 +100,11 @@ title: equal_range
       <td>key</td>
       <td>-</td>
       <td>key value of the elements to search for</td>
+    </tr>
+    <tr class="t-par">
+      <td>x</td>
+      <td>-</td>
+      <td>a value of any type that can be transparently compared with a key</td>
     </tr>
   </tbody>
 </table>

--- a/_docs/vector_of_unique/equal_range.html
+++ b/_docs/vector_of_unique/equal_range.html
@@ -1,0 +1,99 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: vector_of_unique_method
+title: equal_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx11">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><a
+              href="https://en.cppreference.com/w/cpp/utility/pair"
+              title="std::pair"
+              ><span class="kw1773">std::<span class="me2">pair</span></span></a
+            ><span class="sy1">&lt;</span>const_iterator, const_iterator<span
+              class="sy1"
+              >&gt;</span
+            >
+            equal_range<span class="br0">(</span>
+            <span class="kw4">const</span> Key<span class="sy3">&amp;</span> key
+            <span class="br0">)</span> <span class="kw4">const</span
+            ><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="t-li1">
+  <span class="t-li">1)</span> Returns a range containing all elements with key
+  equivalent to
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">key</span></span>.
+  Since all elements in the container are unique, the returned range contains at
+  most one element.
+</div>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>key</td>
+      <td>-</td>
+      <td>key value of the elements to search for</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>
+  A
+  <span class="t-lc"
+    ><a
+      href="https://en.cppreference.com/w/cpp/utility/pair"
+      title="std::pair"
+      >std::pair</a
+    ></span
+  >
+  of
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp">const_iterator</span></span
+  >s. Since all elements are unique, the range is either
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">{it, it+1}</span></span>
+  if an element with the given key is found, or
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >{<a
+        href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+        title="containerofunique/vector_of_unique/cend"
+        >cend()</a
+      >,
+      <a
+        href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+        title="containerofunique/vector_of_unique/cend"
+        >cend()</a
+      >}</span
+    ></span
+  >
+  if not found.
+</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  <span class="texhtml" style="white-space: nowrap">O(N)</span>, where
+  <span class="texhtml" style="white-space: nowrap">N</span> is the size of the
+  container.
+</p>

--- a/_docs/vector_of_unique/equal_range.html
+++ b/_docs/vector_of_unique/equal_range.html
@@ -146,7 +146,9 @@ title: equal_range
   <span class="mw-headline" id="Complexity">Complexity</span>
 </h3>
 <p>
-  <span class="texhtml" style="white-space: nowrap">O(N)</span>, where
-  <span class="texhtml" style="white-space: nowrap">N</span> is the size of the
-  container.
+  Average case: <span class="texhtml" style="white-space: nowrap">O(N)</span>,
+  where <span class="texhtml" style="white-space: nowrap">N</span> is the size
+  of the container (hash lookup is O(1) average, but a linear scan of the
+  sequence is required to obtain a sequence iterator).<br />
+  Worst case: <span class="texhtml" style="white-space: nowrap">O(N)</span>.
 </p>

--- a/_docs/vector_of_unique/index.html
+++ b/_docs/vector_of_unique/index.html
@@ -1013,7 +1013,9 @@ title: vector_of_unique
         </div>
       </td>
       <td>
-        &nbsp;returns range of elements matching a specific key&nbsp;
+        &nbsp;returns range of elements matching a specific key; supports
+        heterogeneous lookup (C++20) when <code>Hash::is_transparent</code> and
+        <code>KeyEqual::is_transparent</code> are defined&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>

--- a/_docs/vector_of_unique/index.html
+++ b/_docs/vector_of_unique/index.html
@@ -867,6 +867,84 @@ title: vector_of_unique
         <span class="t-mark">(public member function)</span>
       </td>
     </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="assign_range"
+              title="containerofunique/vector_of_unique/assign_range"
+            >
+              <span>assign_range</span>
+            </a>
+          </div>
+          <div>
+            <span class="t-lines"
+              ><span
+                ><span class="t-mark-rev t-since-cxx23">(C++23)</span></span
+              ></span
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;replaces contents with unique elements from a range&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="insert_range"
+              title="containerofunique/vector_of_unique/insert_range"
+            >
+              <span>insert_range</span>
+            </a>
+          </div>
+          <div>
+            <span class="t-lines"
+              ><span
+                ><span class="t-mark-rev t-since-cxx23">(C++23)</span></span
+              ></span
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;inserts unique elements from a range before a position&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="append_range"
+              title="containerofunique/vector_of_unique/append_range"
+            >
+              <span>append_range</span>
+            </a>
+          </div>
+          <div>
+            <span class="t-lines"
+              ><span
+                ><span class="t-mark-rev t-since-cxx23">(C++23)</span></span
+              ></span
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;appends unique elements from a range to the end&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
     <tr>
       <td colspan="2">
         <h5>
@@ -885,7 +963,9 @@ title: vector_of_unique
         </div>
       </td>
       <td>
-        &nbsp;finds element with specific key&nbsp;
+        &nbsp;finds element with specific key; supports heterogeneous lookup
+        (C++20) when <code>Hash::is_transparent</code> and
+        <code>KeyEqual::is_transparent</code> are defined&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>
@@ -911,7 +991,29 @@ title: vector_of_unique
         </div>
       </td>
       <td>
-        &nbsp;checks if the container contains element with specific key&nbsp;
+        &nbsp;checks if the container contains element with specific key;
+        supports heterogeneous lookup (C++20) when
+        <code>Hash::is_transparent</code> and
+        <code>KeyEqual::is_transparent</code> are defined&nbsp;
+        <br />
+        <span class="t-mark">(public member function)</span>
+      </td>
+    </tr>
+    <tr class="t-dsc">
+      <td>
+        <div class="t-dsc-member-div">
+          <div>
+            <a
+              href="equal_range"
+              title="containerofunique/vector_of_unique/equal_range"
+            >
+              <span>equal_range</span>
+            </a>
+          </div>
+        </div>
+      </td>
+      <td>
+        &nbsp;returns range of elements matching a specific key&nbsp;
         <br />
         <span class="t-mark">(public member function)</span>
       </td>

--- a/_docs/vector_of_unique/insert_range.html
+++ b/_docs/vector_of_unique/insert_range.html
@@ -40,34 +40,24 @@ title: insert_range
   <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
 </p>
 <p>
-  All iterators (including the
+  If after the operation the new
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">size()</span></span>
+  is greater than the old
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">capacity()</span></span>,
+  a reallocation takes place, in which case all iterators (including the
   <a
     href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
     title="containerofunique/vector_of_unique/cend"
     ><code>cend()</code></a
   >
-  iterator) are invalidated. References are invalidated too, unless
-  <span class="t-c"
-    ><span class="mw-geshi cpp source-cpp"
-      >pos <span class="sy1">==</span></span
-    ><code>&nbsp;</code
-    ><a
-      href="{{ '/_docs/vector_of_unique/cbegin' | relative_url }}"
-      title="containerofunique/vector_of_unique/cbegin"
-      ><code>cbegin()</code></a
-    ></span
+  iterator) and all references to the elements are invalidated. Otherwise, only
+  the iterators and references at or after the insertion point (including the
+  <a
+    href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+    title="containerofunique/vector_of_unique/cend"
+    ><code>cend()</code></a
   >
-  or
-  <span class="t-c"
-    ><span class="mw-geshi cpp source-cpp"
-      >pos <span class="sy1">==</span></span
-    ><code>&nbsp;</code
-    ><a
-      href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
-      title="containerofunique/vector_of_unique/cend"
-      ><code>cend()</code></a
-    ></span
-  >, in which case they are not invalidated.
+  iterator) are invalidated.
 </p>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>

--- a/_docs/vector_of_unique/insert_range.html
+++ b/_docs/vector_of_unique/insert_range.html
@@ -39,6 +39,36 @@ title: insert_range
   Only available when
   <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
 </p>
+<p>
+  All iterators (including the
+  <a
+    href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+    title="containerofunique/vector_of_unique/cend"
+    ><code>cend()</code></a
+  >
+  iterator) are invalidated. References are invalidated too, unless
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >pos <span class="sy1">==</span></span
+    ><code>&nbsp;</code
+    ><a
+      href="{{ '/_docs/vector_of_unique/cbegin' | relative_url }}"
+      title="containerofunique/vector_of_unique/cbegin"
+      ><code>cbegin()</code></a
+    ></span
+  >
+  or
+  <span class="t-c"
+    ><span class="mw-geshi cpp source-cpp"
+      >pos <span class="sy1">==</span></span
+    ><code>&nbsp;</code
+    ><a
+      href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
+      title="containerofunique/vector_of_unique/cend"
+      ><code>cend()</code></a
+    ></span
+  >, in which case they are not invalidated.
+</p>
 <h3>
   <span class="mw-headline" id="Parameters">Parameters</span>
 </h3>

--- a/_docs/vector_of_unique/insert_range.html
+++ b/_docs/vector_of_unique/insert_range.html
@@ -1,0 +1,74 @@
+---
+last_modified_at: "2026-03-21 00:00:00 +0800"
+layout: vector_of_unique_method
+title: insert_range
+---
+
+<table class="t-dcl-begin">
+  <tbody>
+    <tr class="t-dcl t-since-cxx23">
+      <td>
+        <div>
+          <span class="mw-geshi cpp source-cpp"
+            ><span class="kw1">template</span><span class="sy1">&lt;</span>
+            <span class="kw1">class</span> R <span class="sy1">&gt;</span><br />
+            iterator insert_range<span class="br0">(</span>const_iterator pos, R<span class="sy3">&amp;&amp;</span> rng<span class="br0">)</span><span class="sy4">;</span></span
+          >
+        </div>
+      </td>
+      <td>(1)</td>
+      <td><span class="t-mark-rev t-since-cxx23">(since C++23)</span></td>
+    </tr>
+    <tr class="t-dcl-sep">
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  Inserts unique elements from the range
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>
+  before
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">pos</span></span>.
+  Elements already present in the container and intra-range duplicates are
+  silently skipped.
+</p>
+<p>
+  Only available when
+  <span class="mw-geshi cpp source-cpp">__cplusplus &gt;= 202302L</span>.
+</p>
+<h3>
+  <span class="mw-headline" id="Parameters">Parameters</span>
+</h3>
+<table class="t-par-begin">
+  <tbody>
+    <tr class="t-par">
+      <td>pos</td>
+      <td>-</td>
+      <td>iterator before which the new elements will be inserted</td>
+    </tr>
+    <tr class="t-par">
+      <td>rng</td>
+      <td>-</td>
+      <td>a range of elements to insert</td>
+    </tr>
+  </tbody>
+</table>
+<h3>
+  <span class="mw-headline" id="Return_value">Return value</span>
+</h3>
+<p>
+  Iterator pointing to the first inserted element, or
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">pos</span></span>
+  if no elements were inserted.
+</p>
+<h3>
+  <span class="mw-headline" id="Complexity">Complexity</span>
+</h3>
+<p>
+  Average case: linear in the size of
+  <span class="t-c"><span class="mw-geshi cpp source-cpp">rng</span></span>.
+  Worst case: quadratic.
+</p>

--- a/_docs/vector_of_unique/insert_range.html
+++ b/_docs/vector_of_unique/insert_range.html
@@ -51,7 +51,7 @@ title: insert_range
     ><code>cend()</code></a
   >
   iterator) and all references to the elements are invalidated. Otherwise, only
-  the iterators and references at or after the insertion point (including the
+  the iterators at or after the insertion point (including the
   <a
     href="{{ '/_docs/vector_of_unique/cend' | relative_url }}"
     title="containerofunique/vector_of_unique/cend"

--- a/_includes/deque_of_unique_navbar.html
+++ b/_includes/deque_of_unique_navbar.html
@@ -319,6 +319,23 @@
                           </td>
                         </tr>
                         <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/deque_of_unique/equal_range' | relative_url }}"
+                                  title="containerofunique/deque_of_unique/equal_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >deque_of_unique::equal_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
                           <td colspan="5"><br /></td>
                         </tr>
                       </tbody>
@@ -550,6 +567,110 @@
                                   ><span class="t-lines"
                                     ><span>deque_of_unique::swap</span></span
                                   ></a
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/deque_of_unique/assign_range' | relative_url }}"
+                                  title="containerofunique/deque_of_unique/assign_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >deque_of_unique::assign_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                              <div>
+                                <span class="t-lines"
+                                  ><span
+                                    ><span class="t-mark-rev t-since-cxx23"
+                                      >(C++23)</span
+                                    ></span
+                                  ></span
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/deque_of_unique/insert_range' | relative_url }}"
+                                  title="containerofunique/deque_of_unique/insert_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >deque_of_unique::insert_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                              <div>
+                                <span class="t-lines"
+                                  ><span
+                                    ><span class="t-mark-rev t-since-cxx23"
+                                      >(C++23)</span
+                                    ></span
+                                  ></span
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/deque_of_unique/append_range' | relative_url }}"
+                                  title="containerofunique/deque_of_unique/append_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >deque_of_unique::append_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                              <div>
+                                <span class="t-lines"
+                                  ><span
+                                    ><span class="t-mark-rev t-since-cxx23"
+                                      >(C++23)</span
+                                    ></span
+                                  ></span
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/deque_of_unique/prepend_range' | relative_url }}"
+                                  title="containerofunique/deque_of_unique/prepend_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >deque_of_unique::prepend_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                              <div>
+                                <span class="t-lines"
+                                  ><span
+                                    ><span class="t-mark-rev t-since-cxx23"
+                                      >(C++23)</span
+                                    ></span
+                                  ></span
                                 >
                               </div>
                             </div>

--- a/_includes/vector_of_unique_navbar.html
+++ b/_includes/vector_of_unique_navbar.html
@@ -330,6 +330,23 @@
                             </div>
                           </td>
                         </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/vector_of_unique/equal_range' | relative_url }}"
+                                  title="containerofunique/vector_of_unique/equal_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >vector_of_unique::equal_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
                         <tr class="t-nv-h2">
                           <td colspan="5">
                             <a
@@ -503,6 +520,84 @@
                                   ><span class="t-lines"
                                     ><span>vector_of_unique::swap</span></span
                                   ></a
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/vector_of_unique/assign_range' | relative_url }}"
+                                  title="containerofunique/vector_of_unique/assign_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >vector_of_unique::assign_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                              <div>
+                                <span class="t-lines"
+                                  ><span
+                                    ><span class="t-mark-rev t-since-cxx23"
+                                      >(C++23)</span
+                                    ></span
+                                  ></span
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/vector_of_unique/insert_range' | relative_url }}"
+                                  title="containerofunique/vector_of_unique/insert_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >vector_of_unique::insert_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                              <div>
+                                <span class="t-lines"
+                                  ><span
+                                    ><span class="t-mark-rev t-since-cxx23"
+                                      >(C++23)</span
+                                    ></span
+                                  ></span
+                                >
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr class="t-nv">
+                          <td colspan="5">
+                            <div class="t-nv-ln-table">
+                              <div>
+                                <a
+                                  href="{{ '/_docs/vector_of_unique/append_range' | relative_url }}"
+                                  title="containerofunique/vector_of_unique/append_range"
+                                  ><span class="t-lines"
+                                    ><span
+                                      >vector_of_unique::append_range</span
+                                    ></span
+                                  ></a
+                                >
+                              </div>
+                              <div>
+                                <span class="t-lines"
+                                  ><span
+                                    ><span class="t-mark-rev t-since-cxx23"
+                                      >(C++23)</span
+                                    ></span
+                                  ></span
                                 >
                               </div>
                             </div>


### PR DESCRIPTION
## Summary

- **C++23 range modifier methods**: Add `assign_range`, `insert_range`, `append_range` (both containers) and `prepend_range` (`deque_of_unique` only) to the Modifiers section in both index pages, with individual method detail pages
- **`equal_range`**: Add to the Look up section for both containers, with individual method detail pages; documents the unique-element behavior (`{it, it+1}` or `{cend(), cend()}`)
- **Heterogeneous lookup notes**: Update `find` and `contains` index descriptions to note that heterogeneous lookup is supported (C++20) when `Hash::is_transparent` and `KeyEqual::is_transparent` are defined (the individual method pages already documented this overload)
- Update navbars for both containers to include all new methods

## Test plan

- [ ] Verify Jekyll site builds without errors
- [ ] Check that new method pages render correctly under both `/vector_of_unique/` and `/deque_of_unique/`
- [ ] Confirm navbar links resolve to the correct pages
- [ ] Verify C++23 and C++20 version markers display correctly
- [ ] Confirm `prepend_range` only appears under `deque_of_unique`

🤖 Generated with [Claude Code](https://claude.com/claude-code)