### PR TITLE
Remove "Under development" label from vector_of_unique

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ last_modified_at: "2025-01-06 19:22:26 +0800"
           </b>
         </p>
       </td>
-      <td>(Under development)</td>
+      <td></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary

- Remove the "(Under development)" label next to `vector_of_unique` on the homepage

## Test plan

- [ ] Verify the homepage no longer shows "(Under development)" next to `vector_of_unique`

🤖 Generated with [Claude Code](https://claude.com/claude-code)